### PR TITLE
Bump pgjdbc-ng to version 0.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "MIT"
             :url "https://choosealicense.com/licenses/mit/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.7.1"]
+                 [com.impossibl.pgjdbc-ng/pgjdbc-ng "0.8.1"]
                  [org.clojure/data.json "0.2.6"]
                  [com.taoensso/timbre "4.10.0"]]
   :main ^:skip-aot postgres-listener.core

--- a/src/postgres_listener/core.clj
+++ b/src/postgres_listener/core.clj
@@ -63,6 +63,6 @@
   (reset! datasource (doto (PGDataSource.)
                        (.setHost host)
                        (.setPort port)
-                       (.setDatabase database)
+                       (.setDatabaseName database)
                        (.setUser user)
                        (.setPassword password))))


### PR DESCRIPTION
Current version will invoke warning like:
WARNING: An illegal reflective access operation has occurred                                                                            
WARNING: Illegal reflective access by io.netty.util.internal.PlatformDependent0 (file:/home/tienson/.m2/repository/io/netty/netty-common
/4.1.4.Final/netty-common-4.1.4.Final.jar) to field java.nio.Buffer.address                                                             
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.PlatformDependent0                                 
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations